### PR TITLE
Add .gitattributes for $Id$ lines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rng ident


### PR DESCRIPTION
This is similar to what those $Id$ lines did in subversion:

> Git replaces $Id$ in the blob object with $Id:, followed by the
> 40-character hexadecimal blob object name, followed by a dollar sign $
> upon checkout.

(from gitattributes(5)).