### PR TITLE
MBS-8980: CDStubs have "disambiguation" not "comment"

### DIFF
--- a/schema/musicbrainz_mmd-2.0.rng
+++ b/schema/musicbrainz_mmd-2.0.rng
@@ -1635,7 +1635,7 @@
                 </element>
             </optional>
             <optional>
-                <element name="comment">
+                <element name="disambiguation">
                     <text/>
                 </element>
             </optional>


### PR DESCRIPTION
See https://beta.musicbrainz.org/ws/2/discid/o9ToGYQVMvLT5RBIjGQtx02yw_g- - I assume that means we have no tests for this, or it would have been detected.