### PR TITLE
Document mmd-schema 2.0 meaning and git tag

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,11 @@ music metadata and is used by the MusicBrainz web service.
 Some older versions of the schema are included, too, but only
 schema/musicbrainz_mmd-2.0.rng is the official, current version.
 
+Please note that 2.0 version is continuously updated:
+- 2 is the major version matching MusicBrainz web service version;
+- 0 was supposed to be the minor version but has never been changed
+  due to historical reason, please refer to the git tag instead.
+
 Documentation and the latest revision can be found at
 
         http://musicbrainz.org/development/mmd/

--- a/README
+++ b/README
@@ -9,10 +9,10 @@ music metadata and is used by the MusicBrainz web service.
 Some older versions of the schema are included, too, but only
 schema/musicbrainz_mmd-2.0.rng is the official, current version.
 
-Please note that 2.0 version is continuously updated:
-- 2 is the major version matching MusicBrainz web service version;
-- 0 was supposed to be the minor version but has never been changed
-  due to historical reason, please refer to the git tag instead.
+Please note that the 2.0 version is continuously updated:
+- 2 is the major version matching the MusicBrainz web service version;
+- 0 was supposed to be the minor version, but has never been changed
+  due to historical reasons. Please refer to the git tag instead.
 
 Documentation and the latest revision can be found at
 


### PR DESCRIPTION
Current MMD Schema is version 2.0. The minor number 0 has never been updated for the last 10 years. Updating it now is not an option as that would break any client that expects version 2.0 from the web service output. So far, MusicBrainz server and search servers have rather relied on commit identifier to retrieve mmd-schema. It should now rely on git tag set after date of readiness for production, such as [v-2019-01-07](https://github.com/metabrainz/mmd-schema/releases/tag/v-2019-01-07).

This patch documents the facts that mmd-2.0 is rolling-released and that git tag can be referred to.