### PR TITLE
MBS-12367 (I): Allow MBID for artist credit elements

### DIFF
--- a/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/ArtistCredit.java
+++ b/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/ArtistCredit.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
@@ -29,6 +30,7 @@ import javax.xml.bind.annotation.XmlType;
  *       &lt;sequence&gt;
  *         &lt;element ref="{http://musicbrainz.org/ns/mmd-2.0#}name-credit" maxOccurs="unbounded"/&gt;
  *       &lt;/sequence&gt;
+ *       &lt;attribute name="id" type="{http://musicbrainz.org/ns/mmd-2.0#}def_uuid" /&gt;
  *     &lt;/restriction&gt;
  *   &lt;/complexContent&gt;
  * &lt;/complexType&gt;
@@ -45,6 +47,8 @@ public class ArtistCredit {
 
     @XmlElement(name = "name-credit", required = true)
     protected List<NameCredit> nameCredit;
+    @XmlAttribute(name = "id")
+    protected String id;
 
     /**
      * Gets the value of the nameCredit property.
@@ -73,6 +77,30 @@ public class ArtistCredit {
             nameCredit = new ArrayList<NameCredit>();
         }
         return this.nameCredit;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the value of the id property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
     }
 
 }

--- a/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
+++ b/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
@@ -531,6 +531,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="mmd-2.0:name-credit"/>
       </xs:sequence>
+      <xs:attribute name="id" type="mmd-2.0:def_uuid"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="name-credit">

--- a/schema/musicbrainz_mmd-2.0.rng
+++ b/schema/musicbrainz_mmd-2.0.rng
@@ -1304,6 +1304,11 @@
 
     <define name="def_artist-credit">
         <element name="artist-credit">
+            <optional>
+                <attribute name="id">
+                    <ref name="def_uuid"/>
+                </attribute>
+            </optional>
             <oneOrMore>
                 <element name="name-credit">
                     <optional>


### PR DESCRIPTION
# MBS-12367

Allow adding attribute `id` (for MBID) to `artist-credit` elements.

It is a prerequisite for returning MBIDs in API and search API results.