### PR TITLE
Remove CVS ID

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,3 @@ Documentation and the latest revision can be found at
 Questions about this format should be posted to the MusicBrainz
 forums (http://community.metabrainz.org) or brought up on the 
 #metabrainz IRC channel on Libera.Chat.
-
---
-$Id$


### PR DESCRIPTION
We've not used CVS for a long time, and now github is trying to render this as mathjax (It's italicised!)