### PR TITLE
Update docker command to regenerate schema files

### DIFF
--- a/brainz-mmd2-jaxb/README.md
+++ b/brainz-mmd2-jaxb/README.md
@@ -14,7 +14,7 @@ Whenever the MMD RELAX NG definition is modified,
 regenerate the XSD schema and the Java classes with:
 
 ```sh
-docker compose --project-directory=docker/brainz-mmd2-jaxb run --rm builder
+docker compose --project-directory=docker/brainz-mmd2-jaxb run --build --rm builder
 ```
 
 ## Maven artifact


### PR DESCRIPTION
Unless build is specified, docker compose won't rebuild the image for the containers even if the contents of the Dockerfile change.