### PR TITLE
 MBS-13901: Add collection description element

### DIFF
--- a/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Collection.java
+++ b/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Collection.java
@@ -27,6 +27,7 @@ import jakarta.xml.bind.annotation.XmlType;
  *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
  *       <sequence>
  *         <element ref="{http://musicbrainz.org/ns/mmd-2.0#}name"/>
+ *         <element ref="{http://musicbrainz.org/ns/mmd-2.0#}description" minOccurs="0"/>
  *         <element name="editor" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         <element ref="{http://musicbrainz.org/ns/mmd-2.0#}area-list" minOccurs="0"/>
  *         <element ref="{http://musicbrainz.org/ns/mmd-2.0#}artist-list" minOccurs="0"/>
@@ -55,6 +56,7 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {
     "name",
+    "description",
     "editor",
     "areaList",
     "artistList",
@@ -74,6 +76,7 @@ public class Collection {
 
     @XmlElement(required = true)
     protected String name;
+    protected String description;
     protected String editor;
     @XmlElement(name = "area-list")
     protected AreaList areaList;
@@ -133,6 +136,30 @@ public class Collection {
      */
     public void setName(String value) {
         this.name = value;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the value of the description property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setDescription(String value) {
+        this.description = value;
     }
 
     /**

--- a/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
+++ b/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ==================================================================
-  $Id: 9b44987ba812c058a5e79359a0b6f0f4370a3786 $
+  $Id: a00eba6318ee46201d4495da0a4608a8f61985e3 $
   
   Relax NG Schema for MusicBrainz XML Metadata Version 2.0
   
@@ -784,6 +784,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="mmd-2.0:name"/>
+        <xs:element minOccurs="0" ref="mmd-2.0:description"/>
         <xs:element minOccurs="0" name="editor" type="xs:string"/>
         <xs:element minOccurs="0" ref="mmd-2.0:area-list"/>
         <xs:element minOccurs="0" ref="mmd-2.0:artist-list"/>

--- a/schema/musicbrainz_mmd-2.0.rng
+++ b/schema/musicbrainz_mmd-2.0.rng
@@ -1766,6 +1766,11 @@
                 <text/>
             </element>
             <optional>
+                <element name="description">
+                    <text/>
+                </element>
+            </optional>
+            <optional>
                 <element name="editor">
                     <text/>
                 </element>


### PR DESCRIPTION
Adds support for outputting a `<description>` element for a collection, containing its description as text.