### PR TITLE
MBS-13768: Allow MBID for medium elements

### DIFF
--- a/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Medium.java
+++ b/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Medium.java
@@ -37,6 +37,7 @@ import jakarta.xml.bind.annotation.XmlType;
  *         <group ref="{http://musicbrainz.org/ns/mmd-2.0#}def_track-list"/>
  *         <element ref="{http://musicbrainz.org/ns/mmd-2.0#}data-track-list" minOccurs="0"/>
  *       </sequence>
+ *       <attribute name="id" type="{http://musicbrainz.org/ns/mmd-2.0#}def_uuid" />
  *     </restriction>
  *   </complexContent>
  * </complexType>
@@ -68,6 +69,8 @@ public class Medium {
     protected Medium.TrackList trackList;
     @XmlElement(name = "data-track-list")
     protected DataTrackList dataTrackList;
+    @XmlAttribute(name = "id")
+    protected String id;
 
     /**
      * Gets the value of the title property.
@@ -235,6 +238,30 @@ public class Medium {
      */
     public void setDataTrackList(DataTrackList value) {
         this.dataTrackList = value;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the value of the id property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
     }
 
 

--- a/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
+++ b/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ==================================================================
-  $Id: 9b44987ba812c058a5e79359a0b6f0f4370a3786 $
+  $Id: a00eba6318ee46201d4495da0a4608a8f61985e3 $
   
   Relax NG Schema for MusicBrainz XML Metadata Version 2.0
   
@@ -679,6 +679,7 @@
         <xs:group ref="mmd-2.0:def_track-list"/>
         <xs:element minOccurs="0" ref="mmd-2.0:data-track-list"/>
       </xs:sequence>
+      <xs:attribute name="id" type="mmd-2.0:def_uuid"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="position" type="xs:nonNegativeInteger"/>

--- a/schema/musicbrainz_mmd-2.0.rng
+++ b/schema/musicbrainz_mmd-2.0.rng
@@ -1557,6 +1557,11 @@
     <define name="def_medium">
         <element name="medium">
             <optional>
+                <attribute name="id">
+                    <ref name="def_uuid"/>
+                </attribute>
+            </optional>
+            <optional>
                 <element name="title">
                     <text/>
                 </element>


### PR DESCRIPTION
## MBS-13768

Allow adding attribute `id` (for MBID) to `medium` elements.

It is a prerequisite for returning MBIDs in API and search API results

MBS: https://github.com/metabrainz/musicbrainz-server/pull/3502