### PR TITLE
MBS-14053 (schema): Add ended flag to aliases

### DIFF
--- a/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Alias.java
+++ b/brainz-mmd2-jaxb/src/main/java/org/musicbrainz/mmd2/Alias.java
@@ -32,6 +32,7 @@ import jakarta.xml.bind.annotation.XmlValue;
  *       <attribute name="primary" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
  *       <attribute name="begin-date" type="{http://musicbrainz.org/ns/mmd-2.0#}def_incomplete-date" />
  *       <attribute name="end-date" type="{http://musicbrainz.org/ns/mmd-2.0#}def_incomplete-date" />
+ *       <attribute name="ended" type="{http://www.w3.org/2001/XMLSchema}anySimpleType" />
  *     </restriction>
  *   </complexContent>
  * </complexType>
@@ -65,6 +66,9 @@ public class Alias {
     protected String beginDate;
     @XmlAttribute(name = "end-date")
     protected String endDate;
+    @XmlAttribute(name = "ended")
+    @XmlSchemaType(name = "anySimpleType")
+    protected String ended;
 
     /**
      * Gets the value of the content property.
@@ -256,6 +260,30 @@ public class Alias {
      */
     public void setEndDate(String value) {
         this.endDate = value;
+    }
+
+    /**
+     * Gets the value of the ended property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getEnded() {
+        return ended;
+    }
+
+    /**
+     * Sets the value of the ended property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setEnded(String value) {
+        this.ended = value;
     }
 
 }

--- a/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
+++ b/brainz-mmd2-jaxb/src/main/resources/musicbrainz_mmd-2.0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ==================================================================
-  $Id: a00eba6318ee46201d4495da0a4608a8f61985e3 $
+  $Id: b64a047e85d0628c4d0b2b8f2bfa814c12550df4 $
   
   Relax NG Schema for MusicBrainz XML Metadata Version 2.0
   
@@ -595,6 +595,7 @@
       <xs:attribute name="primary"/>
       <xs:attribute name="begin-date" type="mmd-2.0:def_incomplete-date"/>
       <xs:attribute name="end-date" type="mmd-2.0:def_incomplete-date"/>
+      <xs:attribute name="ended"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="iswc">

--- a/schema/musicbrainz_mmd-2.0.rng
+++ b/schema/musicbrainz_mmd-2.0.rng
@@ -1434,6 +1434,11 @@
                 <ref name="def_incomplete-date"/>
               </attribute>
             </optional>
+            <optional>
+              <attribute name="ended">
+                <text />
+              </attribute>
+            </optional>
             <text/>
         </element>
     </define>


### PR DESCRIPTION
### Implement MBS-14053 (I)

# Description
This adds an `ended` attribute to aliases in XML to match what we already do in JSON. While ideally we would probably add a `life-span` element to aliases, that would be a big change given we already do dates as attributes, so it's probably better left for ws/3. For now, this matches what we do for the `primary` boolean.

Associated musicbrainz-server PR: https://github.com/metabrainz/musicbrainz-server/pull/3559
